### PR TITLE
fix(meilisearch): corriger la taille des batch

### DIFF
--- a/config/meilisearch/constante/index.ts
+++ b/config/meilisearch/constante/index.ts
@@ -2,5 +2,5 @@
 export default class Constante {
   public static readonly LIMITE_MAX_FACETS = 100000;
   public static readonly LIMITE_MAX_HITS= 100000;
-  public static readonly LIMITE_ENTRIES_QUERY = 5000;
+  public static readonly LIMITE_ENTRIES_QUERY = process.env.MEILISEARCH_BATCH_SIZE;
 }


### PR DESCRIPTION
Réduire la taille des batchs pour Meilisearch pour limiter l'impact sur l'erreur d'indexation