### PR TITLE
fix: ajoute droits stages et mesures jeunes pour synchro en recette et prod

### DIFF
--- a/config/config-sync/files/admin-role.strapi-author.json
+++ b/config/config-sync/files/admin-role.strapi-author.json
@@ -14,7 +14,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
@@ -22,7 +23,8 @@
       "properties": {},
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -35,7 +37,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -48,7 +51,68 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "subject": "api::actualite.actualite",
+      "properties": {
+        "fields": [
+          "listeActualites.titre",
+          "listeActualites.contenu",
+          "listeActualites.banniere",
+          "listeActualites.url",
+          "listeActualites.article"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "subject": "api::actualite.actualite",
+      "properties": {},
+      "conditions": [
+        "admin::is-creator"
+      ],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "subject": "api::actualite.actualite",
+      "properties": {
+        "fields": [
+          "listeActualites.titre",
+          "listeActualites.contenu",
+          "listeActualites.banniere",
+          "listeActualites.url",
+          "listeActualites.article"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::actualite.actualite",
+      "properties": {
+        "fields": [
+          "listeActualites.titre",
+          "listeActualites.contenu",
+          "listeActualites.banniere",
+          "listeActualites.url",
+          "listeActualites.article"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -93,7 +157,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
@@ -101,55 +166,11 @@
       "properties": {},
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "subject": "api::annonce-de-logement.annonce-de-logement",
-      "properties": {
-        "fields": [
-          "identifiantSource",
-          "titre",
-          "description",
-          "url",
-          "source",
-          "typeBien",
-          "type",
-          "surface",
-          "surfaceMax",
-          "nombreDePieces",
-          "etage",
-          "dateDeDisponibilite",
-          "bilanEnergetique.consommationEnergetique",
-          "bilanEnergetique.emissionDeGaz",
-          "meuble",
-          "localisation.latitude",
-          "localisation.longitude",
-          "localisation.ville",
-          "localisation.adresse",
-          "localisation.departement",
-          "localisation.codePostal",
-          "localisation.region",
-          "localisation.pays",
-          "sourceCreatedAt",
-          "sourceUpdatedAt",
-          "imagesUrl.value",
-          "servicesInclus.nom",
-          "servicesOptionnels.nom",
-          "prixHT",
-          "prix",
-          "devise",
-          "charge",
-          "garantie",
-          "slug"
-        ]
-      },
-      "conditions": [
-        "admin::is-creator"
-      ]
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
       "subject": "api::annonce-de-logement.annonce-de-logement",
       "properties": {
         "fields": [
@@ -191,7 +212,54 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::annonce-de-logement.annonce-de-logement",
+      "properties": {
+        "fields": [
+          "identifiantSource",
+          "titre",
+          "description",
+          "url",
+          "source",
+          "typeBien",
+          "type",
+          "surface",
+          "surfaceMax",
+          "nombreDePieces",
+          "etage",
+          "dateDeDisponibilite",
+          "bilanEnergetique.consommationEnergetique",
+          "bilanEnergetique.emissionDeGaz",
+          "meuble",
+          "localisation.latitude",
+          "localisation.longitude",
+          "localisation.ville",
+          "localisation.adresse",
+          "localisation.departement",
+          "localisation.codePostal",
+          "localisation.region",
+          "localisation.pays",
+          "sourceCreatedAt",
+          "sourceUpdatedAt",
+          "imagesUrl.value",
+          "servicesInclus.nom",
+          "servicesOptionnels.nom",
+          "prixHT",
+          "prix",
+          "devise",
+          "charge",
+          "garantie",
+          "slug"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -206,7 +274,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
@@ -214,7 +283,8 @@
       "properties": {},
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -229,7 +299,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -244,7 +315,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -257,7 +329,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
@@ -265,7 +338,8 @@
       "properties": {},
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -278,7 +352,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -291,7 +366,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -309,7 +385,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
@@ -317,7 +394,8 @@
       "properties": {},
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -335,7 +413,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -353,7 +432,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -376,7 +456,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
@@ -384,7 +465,8 @@
       "properties": {},
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -407,7 +489,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -430,7 +513,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -444,7 +528,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
@@ -452,7 +537,8 @@
       "properties": {},
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -466,7 +552,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -480,7 +567,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -513,7 +601,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
@@ -521,43 +610,11 @@
       "properties": {},
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "subject": "api::fiche-metier.fiche-metier",
-      "properties": {
-        "fields": [
-          "nom_metier",
-          "competences",
-          "condition_travail",
-          "secteurs_activite.identifiant",
-          "secteurs_activite.libelle",
-          "identifiant",
-          "centres_interet.identifiant",
-          "centres_interet.libelle",
-          "niveau_acces_min.libelle",
-          "niveau_acces_min.identifiant",
-          "nature_travail",
-          "vie_professionnelle",
-          "acces_metier",
-          "statuts.identifiant",
-          "statuts.id_ideo1",
-          "statuts.libelle",
-          "formations_min_requise.identifiant",
-          "formations_min_requise.libelle",
-          "accroche_metier",
-          "libelle_feminin",
-          "libelle_masculin",
-          "synonymes"
-        ]
-      },
-      "conditions": [
-        "admin::is-creator"
-      ]
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
       "subject": "api::fiche-metier.fiche-metier",
       "properties": {
         "fields": [
@@ -587,7 +644,42 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::fiche-metier.fiche-metier",
+      "properties": {
+        "fields": [
+          "nom_metier",
+          "competences",
+          "condition_travail",
+          "secteurs_activite.identifiant",
+          "secteurs_activite.libelle",
+          "identifiant",
+          "centres_interet.identifiant",
+          "centres_interet.libelle",
+          "niveau_acces_min.libelle",
+          "niveau_acces_min.identifiant",
+          "nature_travail",
+          "vie_professionnelle",
+          "acces_metier",
+          "statuts.identifiant",
+          "statuts.id_ideo1",
+          "statuts.libelle",
+          "formations_min_requise.identifiant",
+          "formations_min_requise.libelle",
+          "accroche_metier",
+          "libelle_feminin",
+          "libelle_masculin",
+          "synonymes"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -604,7 +696,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
@@ -612,7 +705,8 @@
       "properties": {},
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -629,7 +723,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -646,7 +741,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -659,7 +755,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
@@ -667,7 +764,8 @@
       "properties": {},
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -680,7 +778,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -693,7 +792,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -723,12 +823,25 @@
           "aidesFinancieres.banniere",
           "aidesFinancieres.url",
           "aidesFinancieres.article",
-          "aidesFinancieres.pourQui"
+          "aidesFinancieres.pourQui",
+          "engagement.titre",
+          "engagement.contenu",
+          "engagement.banniere",
+          "engagement.url",
+          "engagement.article",
+          "engagement.pourQui",
+          "logement.titre",
+          "logement.contenu",
+          "logement.banniere",
+          "logement.url",
+          "logement.article",
+          "logement.pourQui"
         ]
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
@@ -736,45 +849,11 @@
       "properties": {},
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "subject": "api::mesure-jeune.mesure-jeune",
-      "properties": {
-        "fields": [
-          "vieProfessionnelle.titre",
-          "vieProfessionnelle.contenu",
-          "vieProfessionnelle.banniere",
-          "vieProfessionnelle.url",
-          "vieProfessionnelle.article",
-          "vieProfessionnelle.pourQui",
-          "orienterFormer.titre",
-          "orienterFormer.contenu",
-          "orienterFormer.banniere",
-          "orienterFormer.url",
-          "orienterFormer.article",
-          "orienterFormer.pourQui",
-          "accompagnement.titre",
-          "accompagnement.contenu",
-          "accompagnement.banniere",
-          "accompagnement.url",
-          "accompagnement.article",
-          "accompagnement.pourQui",
-          "aidesFinancieres.titre",
-          "aidesFinancieres.contenu",
-          "aidesFinancieres.banniere",
-          "aidesFinancieres.url",
-          "aidesFinancieres.article",
-          "aidesFinancieres.pourQui"
-        ]
-      },
-      "conditions": [
-        "admin::is-creator"
-      ]
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
       "subject": "api::mesure-jeune.mesure-jeune",
       "properties": {
         "fields": [
@@ -801,12 +880,73 @@
           "aidesFinancieres.banniere",
           "aidesFinancieres.url",
           "aidesFinancieres.article",
-          "aidesFinancieres.pourQui"
+          "aidesFinancieres.pourQui",
+          "engagement.titre",
+          "engagement.contenu",
+          "engagement.banniere",
+          "engagement.url",
+          "engagement.article",
+          "engagement.pourQui",
+          "logement.titre",
+          "logement.contenu",
+          "logement.banniere",
+          "logement.url",
+          "logement.article",
+          "logement.pourQui"
         ]
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::mesure-jeune.mesure-jeune",
+      "properties": {
+        "fields": [
+          "vieProfessionnelle.titre",
+          "vieProfessionnelle.contenu",
+          "vieProfessionnelle.banniere",
+          "vieProfessionnelle.url",
+          "vieProfessionnelle.article",
+          "vieProfessionnelle.pourQui",
+          "orienterFormer.titre",
+          "orienterFormer.contenu",
+          "orienterFormer.banniere",
+          "orienterFormer.url",
+          "orienterFormer.article",
+          "orienterFormer.pourQui",
+          "accompagnement.titre",
+          "accompagnement.contenu",
+          "accompagnement.banniere",
+          "accompagnement.url",
+          "accompagnement.article",
+          "accompagnement.pourQui",
+          "aidesFinancieres.titre",
+          "aidesFinancieres.contenu",
+          "aidesFinancieres.banniere",
+          "aidesFinancieres.url",
+          "aidesFinancieres.article",
+          "aidesFinancieres.pourQui",
+          "engagement.titre",
+          "engagement.contenu",
+          "engagement.banniere",
+          "engagement.url",
+          "engagement.article",
+          "engagement.pourQui",
+          "logement.titre",
+          "logement.contenu",
+          "logement.banniere",
+          "logement.url",
+          "logement.article",
+          "logement.pourQui"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -823,11 +963,11 @@
           "sourceCreatedAt",
           "sourceUpdatedAt",
           "sourcePublishedAt",
-          "remunerationBase",
           "employeur.nom",
           "employeur.description",
           "employeur.logoUrl",
           "employeur.siteUrl",
+          "employeur.email",
           "domaines.nom",
           "preRequis.niveauEtude",
           "preRequis.profil",
@@ -842,12 +982,16 @@
           "localisation.region",
           "localisation.pays",
           "dateDeDebutMin",
-          "dateDeDebutMax"
+          "dateDeDebutMax",
+          "remunerationMin",
+          "remunerationMax",
+          "remunerationPeriode"
         ]
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
@@ -855,7 +999,8 @@
       "properties": {},
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -872,11 +1017,11 @@
           "sourceCreatedAt",
           "sourceUpdatedAt",
           "sourcePublishedAt",
-          "remunerationBase",
           "employeur.nom",
           "employeur.description",
           "employeur.logoUrl",
           "employeur.siteUrl",
+          "employeur.email",
           "domaines.nom",
           "preRequis.niveauEtude",
           "preRequis.profil",
@@ -891,12 +1036,16 @@
           "localisation.region",
           "localisation.pays",
           "dateDeDebutMin",
-          "dateDeDebutMax"
+          "dateDeDebutMax",
+          "remunerationMin",
+          "remunerationMax",
+          "remunerationPeriode"
         ]
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -913,11 +1062,11 @@
           "sourceCreatedAt",
           "sourceUpdatedAt",
           "sourcePublishedAt",
-          "remunerationBase",
           "employeur.nom",
           "employeur.description",
           "employeur.logoUrl",
           "employeur.siteUrl",
+          "employeur.email",
           "domaines.nom",
           "preRequis.niveauEtude",
           "preRequis.profil",
@@ -932,12 +1081,16 @@
           "localisation.region",
           "localisation.pays",
           "dateDeDebutMin",
-          "dateDeDebutMax"
+          "dateDeDebutMax",
+          "remunerationMin",
+          "remunerationMax",
+          "remunerationPeriode"
         ]
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -950,7 +1103,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
@@ -958,7 +1112,8 @@
       "properties": {},
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -971,7 +1126,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -984,7 +1140,8 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -997,13 +1154,15 @@
           "Index"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::videos-campagne-apprentissage.videos-campagne-apprentissage",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -1016,7 +1175,8 @@
           "Index"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -1029,25 +1189,29 @@
           "Index"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::upload.assets.copy-link",
       "subject": null,
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::upload.assets.create",
       "subject": null,
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::upload.assets.download",
       "subject": null,
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::upload.assets.update",
@@ -1055,7 +1219,8 @@
       "properties": {},
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::upload.read",
@@ -1063,7 +1228,8 @@
       "properties": {},
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     }
   ]
 }

--- a/config/config-sync/files/admin-role.strapi-editor.json
+++ b/config/config-sync/files/admin-role.strapi-editor.json
@@ -12,19 +12,22 @@
           "contenu"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::accessibilite.accessibilite",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.publish",
       "subject": "api::accessibilite.accessibilite",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -35,7 +38,8 @@
           "contenu"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -46,7 +50,8 @@
           "contenu"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -57,23 +62,25 @@
           "listeActualites.contenu",
           "listeActualites.banniere",
           "listeActualites.url",
-          "listeActualites.article",
-          "listeActualites.pourQui"
+          "listeActualites.article"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::actualite.actualite",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.publish",
       "subject": "api::actualite.actualite",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -84,11 +91,11 @@
           "listeActualites.contenu",
           "listeActualites.banniere",
           "listeActualites.url",
-          "listeActualites.article",
-          "listeActualites.pourQui"
+          "listeActualites.article"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -99,11 +106,11 @@
           "listeActualites.contenu",
           "listeActualites.banniere",
           "listeActualites.url",
-          "listeActualites.article",
-          "listeActualites.pourQui"
+          "listeActualites.article"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -146,65 +153,25 @@
           "slug"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::annonce-de-logement.annonce-de-logement",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.publish",
       "subject": "api::annonce-de-logement.annonce-de-logement",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "subject": "api::annonce-de-logement.annonce-de-logement",
-      "properties": {
-        "fields": [
-          "identifiantSource",
-          "titre",
-          "description",
-          "url",
-          "source",
-          "typeBien",
-          "type",
-          "surface",
-          "surfaceMax",
-          "nombreDePieces",
-          "etage",
-          "dateDeDisponibilite",
-          "bilanEnergetique.consommationEnergetique",
-          "bilanEnergetique.emissionDeGaz",
-          "meuble",
-          "localisation.latitude",
-          "localisation.longitude",
-          "localisation.ville",
-          "localisation.adresse",
-          "localisation.departement",
-          "localisation.codePostal",
-          "localisation.region",
-          "localisation.pays",
-          "sourceCreatedAt",
-          "sourceUpdatedAt",
-          "imagesUrl.value",
-          "servicesInclus.nom",
-          "servicesOptionnels.nom",
-          "prixHT",
-          "prix",
-          "devise",
-          "charge",
-          "garantie",
-          "slug"
-        ]
-      },
-      "conditions": []
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
       "subject": "api::annonce-de-logement.annonce-de-logement",
       "properties": {
         "fields": [
@@ -244,7 +211,52 @@
           "slug"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::annonce-de-logement.annonce-de-logement",
+      "properties": {
+        "fields": [
+          "identifiantSource",
+          "titre",
+          "description",
+          "url",
+          "source",
+          "typeBien",
+          "type",
+          "surface",
+          "surfaceMax",
+          "nombreDePieces",
+          "etage",
+          "dateDeDisponibilite",
+          "bilanEnergetique.consommationEnergetique",
+          "bilanEnergetique.emissionDeGaz",
+          "meuble",
+          "localisation.latitude",
+          "localisation.longitude",
+          "localisation.ville",
+          "localisation.adresse",
+          "localisation.departement",
+          "localisation.codePostal",
+          "localisation.region",
+          "localisation.pays",
+          "sourceCreatedAt",
+          "sourceUpdatedAt",
+          "imagesUrl.value",
+          "servicesInclus.nom",
+          "servicesOptionnels.nom",
+          "prixHT",
+          "prix",
+          "devise",
+          "charge",
+          "garantie",
+          "slug"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -257,19 +269,22 @@
           "banniere"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::article.article",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.publish",
       "subject": "api::article.article",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -282,7 +297,8 @@
           "banniere"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -295,7 +311,8 @@
           "banniere"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -306,19 +323,22 @@
           "contenu"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::conditions-generales-d-utilisation.conditions-generales-d-utilisation",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.publish",
       "subject": "api::conditions-generales-d-utilisation.conditions-generales-d-utilisation",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -329,7 +349,8 @@
           "contenu"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -340,7 +361,8 @@
           "contenu"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -356,19 +378,22 @@
           "code_postal"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::contact-cej.contact-cej",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.publish",
       "subject": "api::contact-cej.contact-cej",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -384,7 +409,8 @@
           "code_postal"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -400,7 +426,8 @@
           "code_postal"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -421,19 +448,22 @@
           "dateFin"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::evenement.evenement",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.publish",
       "subject": "api::evenement.evenement",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -454,7 +484,8 @@
           "dateFin"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -475,7 +506,8 @@
           "dateFin"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -487,19 +519,22 @@
           "slug"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::faq.faq",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.publish",
       "subject": "api::faq.faq",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -511,7 +546,8 @@
           "slug"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -523,7 +559,8 @@
           "slug"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -554,47 +591,18 @@
           "synonymes"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::fiche-metier.fiche-metier",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "subject": "api::fiche-metier.fiche-metier",
-      "properties": {
-        "fields": [
-          "nom_metier",
-          "competences",
-          "condition_travail",
-          "secteurs_activite.identifiant",
-          "secteurs_activite.libelle",
-          "identifiant",
-          "centres_interet.identifiant",
-          "centres_interet.libelle",
-          "niveau_acces_min.libelle",
-          "niveau_acces_min.identifiant",
-          "nature_travail",
-          "vie_professionnelle",
-          "acces_metier",
-          "statuts.identifiant",
-          "statuts.id_ideo1",
-          "statuts.libelle",
-          "formations_min_requise.identifiant",
-          "formations_min_requise.libelle",
-          "accroche_metier",
-          "libelle_feminin",
-          "libelle_masculin",
-          "synonymes"
-        ]
-      },
-      "conditions": []
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
       "subject": "api::fiche-metier.fiche-metier",
       "properties": {
         "fields": [
@@ -622,7 +630,40 @@
           "synonymes"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::fiche-metier.fiche-metier",
+      "properties": {
+        "fields": [
+          "nom_metier",
+          "competences",
+          "condition_travail",
+          "secteurs_activite.identifiant",
+          "secteurs_activite.libelle",
+          "identifiant",
+          "centres_interet.identifiant",
+          "centres_interet.libelle",
+          "niveau_acces_min.libelle",
+          "niveau_acces_min.identifiant",
+          "nature_travail",
+          "vie_professionnelle",
+          "acces_metier",
+          "statuts.identifiant",
+          "statuts.id_ideo1",
+          "statuts.libelle",
+          "formations_min_requise.identifiant",
+          "formations_min_requise.libelle",
+          "accroche_metier",
+          "libelle_feminin",
+          "libelle_masculin",
+          "synonymes"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -637,19 +678,22 @@
           "dispositifs.pourQui"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::les-mesures-employeurs.les-mesures-employeurs",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.publish",
       "subject": "api::les-mesures-employeurs.les-mesures-employeurs",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -664,7 +708,8 @@
           "dispositifs.pourQui"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -679,7 +724,8 @@
           "dispositifs.pourQui"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -690,19 +736,22 @@
           "contenu"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::mention-legale.mention-legale",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.publish",
       "subject": "api::mention-legale.mention-legale",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -713,7 +762,8 @@
           "contenu"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -724,7 +774,8 @@
           "contenu"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -754,22 +805,37 @@
           "aidesFinancieres.banniere",
           "aidesFinancieres.url",
           "aidesFinancieres.article",
-          "aidesFinancieres.pourQui"
+          "aidesFinancieres.pourQui",
+          "engagement.titre",
+          "engagement.contenu",
+          "engagement.banniere",
+          "engagement.url",
+          "engagement.article",
+          "engagement.pourQui",
+          "logement.titre",
+          "logement.contenu",
+          "logement.banniere",
+          "logement.url",
+          "logement.article",
+          "logement.pourQui"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::mesure-jeune.mesure-jeune",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.publish",
       "subject": "api::mesure-jeune.mesure-jeune",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -799,10 +865,23 @@
           "aidesFinancieres.banniere",
           "aidesFinancieres.url",
           "aidesFinancieres.article",
-          "aidesFinancieres.pourQui"
+          "aidesFinancieres.pourQui",
+          "engagement.titre",
+          "engagement.contenu",
+          "engagement.banniere",
+          "engagement.url",
+          "engagement.article",
+          "engagement.pourQui",
+          "logement.titre",
+          "logement.contenu",
+          "logement.banniere",
+          "logement.url",
+          "logement.article",
+          "logement.pourQui"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -832,10 +911,23 @@
           "aidesFinancieres.banniere",
           "aidesFinancieres.url",
           "aidesFinancieres.article",
-          "aidesFinancieres.pourQui"
+          "aidesFinancieres.pourQui",
+          "engagement.titre",
+          "engagement.contenu",
+          "engagement.banniere",
+          "engagement.url",
+          "engagement.article",
+          "engagement.pourQui",
+          "logement.titre",
+          "logement.contenu",
+          "logement.banniere",
+          "logement.url",
+          "logement.article",
+          "logement.pourQui"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -852,11 +944,11 @@
           "sourceCreatedAt",
           "sourceUpdatedAt",
           "sourcePublishedAt",
-          "remunerationBase",
           "employeur.nom",
           "employeur.description",
           "employeur.logoUrl",
           "employeur.siteUrl",
+          "employeur.email",
           "domaines.nom",
           "preRequis.niveauEtude",
           "preRequis.profil",
@@ -871,22 +963,28 @@
           "localisation.region",
           "localisation.pays",
           "dateDeDebutMin",
-          "dateDeDebutMax"
+          "dateDeDebutMax",
+          "remunerationMin",
+          "remunerationMax",
+          "remunerationPeriode"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::offre-de-stage.offre-de-stage",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.publish",
       "subject": "api::offre-de-stage.offre-de-stage",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -903,11 +1001,11 @@
           "sourceCreatedAt",
           "sourceUpdatedAt",
           "sourcePublishedAt",
-          "remunerationBase",
           "employeur.nom",
           "employeur.description",
           "employeur.logoUrl",
           "employeur.siteUrl",
+          "employeur.email",
           "domaines.nom",
           "preRequis.niveauEtude",
           "preRequis.profil",
@@ -922,10 +1020,14 @@
           "localisation.region",
           "localisation.pays",
           "dateDeDebutMin",
-          "dateDeDebutMax"
+          "dateDeDebutMax",
+          "remunerationMin",
+          "remunerationMax",
+          "remunerationPeriode"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -942,11 +1044,11 @@
           "sourceCreatedAt",
           "sourceUpdatedAt",
           "sourcePublishedAt",
-          "remunerationBase",
           "employeur.nom",
           "employeur.description",
           "employeur.logoUrl",
           "employeur.siteUrl",
+          "employeur.email",
           "domaines.nom",
           "preRequis.niveauEtude",
           "preRequis.profil",
@@ -961,10 +1063,14 @@
           "localisation.region",
           "localisation.pays",
           "dateDeDebutMin",
-          "dateDeDebutMax"
+          "dateDeDebutMax",
+          "remunerationMin",
+          "remunerationMax",
+          "remunerationPeriode"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -975,19 +1081,22 @@
           "contenu"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::politique-de-confidentialite.politique-de-confidentialite",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.publish",
       "subject": "api::politique-de-confidentialite.politique-de-confidentialite",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -998,7 +1107,8 @@
           "contenu"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -1009,7 +1119,8 @@
           "contenu"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
@@ -1022,13 +1133,15 @@
           "Index"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::videos-campagne-apprentissage.videos-campagne-apprentissage",
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
@@ -1041,7 +1154,8 @@
           "Index"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
@@ -1054,37 +1168,43 @@
           "Index"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::upload.assets.copy-link",
       "subject": null,
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::upload.assets.create",
       "subject": null,
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::upload.assets.download",
       "subject": null,
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::upload.assets.update",
       "subject": null,
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::upload.read",
       "subject": null,
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     }
   ]
 }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "MIT",
       "url": "https://github.com/DNUM-SocialGouv/1j1s-stage-orchestrateur-transform-load/blob/main/LICENSE"
     },
-    "x-generation-date": "2024-07-23T13:59:03.479Z"
+    "x-generation-date": "2024-12-03T09:53:48.108Z"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -6836,6 +6836,7 @@
                 "type": "string",
                 "enum": [
                   "HOURLY",
+                  "DAILY",
                   "MONTHLY",
                   "YEARLY"
                 ]
@@ -6982,6 +6983,7 @@
             "type": "string",
             "enum": [
               "HOURLY",
+              "DAILY",
               "MONTHLY",
               "YEARLY"
             ]


### PR DESCRIPTION
C'était pas sorcier, il suffit de modifier la config en local, et l'exporter via l'interface "config sync" pour ensuite l'importer sur les environnements cibles après déploiement