### PR TITLE
fix(recherche): abaisse maxTotalHits et maxValuesPerFacet pour limiter le coût unitaire Meilisearch

### DIFF
--- a/config/meilisearch/constante/index.ts
+++ b/config/meilisearch/constante/index.ts
@@ -1,6 +1,6 @@
 
 export default class Constante {
-  public static readonly LIMITE_MAX_FACETS = 100000;
-  public static readonly LIMITE_MAX_HITS= 100000;
+  public static readonly LIMITE_MAX_FACETS = 200;
+  public static readonly LIMITE_MAX_HITS= 2000;
   public static readonly LIMITE_ENTRIES_QUERY = process.env.MEILISEARCH_BATCH_SIZE;
 }


### PR DESCRIPTION
## Quoi
Abaisse les deux constantes Meilisearch du CMS (`config/meilisearch/constante/index.ts`) :
* `LIMITE_MAX_HITS` : 100000 vers 2000 (pilote `pagination.maxTotalHits`)
* `LIMITE_MAX_FACETS` : 100000 vers 200 (pilote `faceting.maxValuesPerFacet`)

## Pourquoi
Valeurs de départ aberrantes (×100 et ×1000 face aux défauts Meilisearch). En pagination exhaustive (`hitsPerPage`, utilisé par le front), Meilisearch calcule jusqu'à `maxTotalHits`, ce qui amplifie le coût par requête (issue meilisearch/meilisearch#5776). 2000 couvre la pagination humaine (page 133 sur stages à 15 hits par page) tout en divisant par 50 le travail pire cas.

## Sûreté du plafond de facettes
`maxValuesPerFacet=200` devient sûr grâce à la PR front associée, qui fait passer le filtre localisation au facet search Meilisearch (non borné par ce plafond). À déployer APRÈS la PR front. Preuve moteur : plafond à 200, le facet search remonte tout de même une valeur située au delà des 200 premières.

## Propagation des settings
Le plugin `strapi-plugin-meilisearch` ne renvoie pas forcément les settings au reboot pour un index déjà créé, et une réindexation ETL non plus. Après déploiement, vérifier via l'API (`GET /indexes/<index>/settings/pagination` et `/faceting`) et déclencher au besoin un « Update settings » dans l'admin Strapi, sans réindexer les documents. Index concernés en prod : `offre-de-stage` et `annonce-de-logement` (`evenement` absent en prod).

## Rollback
Remettre 100000 / 100000, redéployer, propager de nouveau. Aucune migration, aucune coupure, rétrocompatible.
