### PR TITLE
fix(ci): fiabilise l'extraction de l'ID addon PostgreSQL pour la sauvegarde prod

### DIFF
--- a/.github/workflows/mise-en-production.yml
+++ b/.github/workflows/mise-en-production.yml
@@ -24,8 +24,15 @@ jobs:
           app_name: ${{ secrets.TF_VAR_NOM_DE_L_APPLICATION }}
       - name: Créer une sauvegarde de la base PostgreSQL Scalingo
         run: |
-          POSTGRESQL_ADDON_ID=$(scalingo addons | grep -i postgresql | awk 'BEGIN{FS=" [|] "}{print $2}')
-          scalingo backups-create --addon $POSTGRESQL_ADDON_ID
+          # L'ID de l'addon est extrait par son motif "ad-<uuid>", robuste au format du tableau
+          # de `scalingo addons` dont les séparateurs de colonnes sont passés en Unicode (│).
+          POSTGRESQL_ADDON_ID=$(scalingo addons | grep -i postgresql | grep -oE 'ad-[0-9a-f-]+' | head -n1)
+          if [ -z "$POSTGRESQL_ADDON_ID" ]; then
+            echo "Erreur : ID de l'addon PostgreSQL introuvable dans la sortie de 'scalingo addons'." >&2
+            scalingo addons
+            exit 1
+          fi
+          scalingo backups-create --addon "$POSTGRESQL_ADDON_ID"
 
   terraform:
     uses: DNUM-SocialGouv/1j1s-front/.github/workflows/terraform-template.yml@main


### PR DESCRIPTION
## Problème

Le job « Sauvegarder la base de données PostgreSQL » de la « Mise en production » échoue sur `flag needs an argument: --addon` ([run](https://github.com/DNUM-SocialGouv/1j1s-main-cms/actions/runs/30616231839)). `POSTGRESQL_ADDON_ID` ressort vide, donc `scalingo backups-create --addon` n'a pas d'argument.

## Cause

`scalingo addons` a changé son format de tableau : les séparateurs de colonnes sont passés des pipes ASCII `|` aux barres Unicode `│`. Le parse `awk 'BEGIN{FS=" [|] "}{print $2}'` (pipe ASCII) ne matche donc plus rien.

## Correctif

L'ID de l'addon est extrait par son motif `ad-<uuid>` via `grep -oE 'ad-[0-9a-f-]+'`, robuste au format du tableau. Un garde-fou échoue clairement et affiche la sortie de `scalingo addons` si l'extraction revient vide, pour éviter le prochain `flag needs an argument` opaque.

Vérifié sur la sortie réelle de `scalingo addons` (prod) : l'ancien parse renvoie une chaîne vide, le nouveau renvoie bien l'ID `ad-70e7dc28-…`. La création du backup elle-même s'exécute en CI.

